### PR TITLE
Add RPCs with optional tokentype parameter

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -203,10 +203,11 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
   end
 
   def tokenlist(conn, params) do
+    options = optional_params(params)
     with {:address_param, {:ok, address_param}} <- fetch_address(params),
          {:format, {:ok, address_hash}} <- to_address_hash(address_param),
          {:address, :ok} <- {:address, Chain.check_address_exists(address_hash)},
-         {:ok, token_list} <- list_tokens(address_hash) do
+         {:ok, token_list} <- list_tokens(address_hash, options) do
       render(conn, :token_list, %{token_list: token_list})
     else
       {:address_param, :error} ->
@@ -545,8 +546,8 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     end
   end
 
-  defp list_tokens(address_hash) do
-    case Etherscan.list_tokens(address_hash) do
+  defp list_tokens(address_hash, options) do
+    case Etherscan.list_tokens(address_hash, options) do
       [] -> {:error, :not_found}
       token_list -> {:ok, token_list}
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -254,6 +254,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     |> put_filter_by(params)
     |> put_start_timestamp(params)
     |> put_end_timestamp(params)
+    |> put_token_type(params)
   end
 
   @doc """
@@ -288,6 +289,12 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
 
   defp fetch_block_param(%{"block" => _block}), do: :error
   defp fetch_block_param(_), do: {:ok, :latest}
+
+  defp format_tokentype(type) do
+    ~r/erc-?(\d+)/i
+    |> Regex.replace(type, "ERC-\\1")
+    |> String.upcase()
+  end
 
   defp to_valid_format(params, :tokenbalance) do
     result =
@@ -441,6 +448,16 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     with %{"endblock" => endblock_param} <- params,
          {end_block, ""} <- Integer.parse(endblock_param) do
       Map.put(options, :end_block, end_block)
+    else
+      _ ->
+        options
+    end
+  end
+
+  defp put_token_type(options, params) do
+    with %{"tokentype" => tokentype_param} <- params,
+         token_type <- format_tokentype(tokentype_param) do
+         Map.put(options, :token_type, token_type)
     else
       _ ->
         options

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -64,26 +64,6 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
     end
   end
 
-  def tokentx(conn, params) do
-    with {:address_param, {:ok, address_param}} <- fetch_address(params),
-         {:tokentype_param, {:ok, token_type}} <- fetch_tokentype(params),
-         {:format, {:ok, address_hash}} <- to_address_hash(address_param)
-    do
-      token_type = token_type |> format_tokentype()
-      transfers = Chain.transfers_by_address_and_type(address_hash, token_type)
-      render(conn, "tokentx.json", %{token_transfers: transfers})
-    else
-      {:contractaddress_param, :error} ->
-        render(conn, :error, error: "Query parameter 'address' is required")
-
-      {:format, :error} ->
-        render(conn, :error, error: "Invalid address hash")
-
-      {:tokentype_param, :error} ->
-        render(conn, :error, error: "Query parameter tokentype is required")
-    end
-  end
-
   def gettokenholders(conn, params) do
     with pagination_options <- Helpers.put_pagination_options(%{}, params),
          {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
@@ -127,16 +107,6 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
 
   defp fetch_tokenid(params) do
     {:tokenid_param, Map.fetch(params, "tokenId")}
-  end
-
-  defp fetch_tokentype(params) do
-    {:tokentype_param, Map.fetch(params, "tokentype")}
-  end
-
-  defp format_tokentype(type) do
-    ~r/erc-?(\d+)/i
-    |> Regex.replace(type, "ERC-\\1")
-    |> String.upcase()
   end
 
   defp to_token_id(token_id_string) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -157,6 +157,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "tokenName" => token_transfer.token_name,
       "tokenSymbol" => token_transfer.token_symbol,
       "tokenDecimal" => to_string(token_transfer.token_decimals),
+      "tokenType" => to_string(token_transfer.token_type),
       "transactionIndex" => to_string(token_transfer.transaction_index),
       "gas" => to_string(token_transfer.transaction_gas),
       "gasPrice" => to_string(token_transfer.transaction_gas_price.value),

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -18,7 +18,8 @@ defmodule Explorer.Etherscan do
     start_block: nil,
     end_block: nil,
     start_timestamp: nil,
-    end_timestamp: nil
+    end_timestamp: nil,
+    token_type: nil
   }
 
   @burn_address_hash_str "0x0000000000000000000000000000000000000000"
@@ -493,6 +494,7 @@ defmodule Explorer.Etherscan do
     wrapped_query
     |> where_start_block_match(options)
     |> where_end_block_match(options)
+    |> where_token_type_matches(options)
     |> Repo.replica().all()
   end
 
@@ -527,6 +529,11 @@ defmodule Explorer.Etherscan do
   end
 
   defp offset(options), do: (options.page_number - 1) * options.page_size
+
+  defp where_token_type_matches(query, %{token_type: nil}), do: query
+  defp where_token_type_matches(query, %{token_type: token_type}) do
+    where(query, [tt, _], tt.token_type == ^token_type)
+  end
 
   @doc """
   Gets a list of logs that meet the criteria in a given filter map.


### PR DESCRIPTION
- The tokentx action was previously implemented in token module. This is now fixed and its new home is in account module.
- The account.token list now accepts an optional tokentype parameter, as well as pagination parameters page_size and offset.