### PR TITLE
Implement account.tokenlistx RPC

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -52,6 +52,10 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     RPCView.render("show.json", data: data)
   end
 
+  def render("token_list_x.json", %{token_list: token_list}) do
+    RPCView.render("show.json", data: token_list)
+  end
+
   def render("getminedblocks.json", %{blocks: blocks}) do
     data = Enum.map(blocks, &prepare_block/1)
     RPCView.render("show.json", data: data)


### PR DESCRIPTION
Adds a new RPC account.tokenlistx.
http://localhost:4000/api?module=account&action=tokenlistx&address=

- `address` is required
- `tokentype` is optional and can be in any format (lower case like "erc721" or uppercase like "ERC-20", with or without the hyphen)